### PR TITLE
Include hyperlink text in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # scraper
-The goal is to create a simple scraper that will compile the text content from a given url
+The goal is to create a simple scraper that will compile the text content from a given URL.
+
+Hyperlink text is also included in the scraped output. Link text is exported in
+the form `text (link)` so you can easily see each hyperlink's destination.


### PR DESCRIPTION
## Summary
- capture hyperlink text as `text (url)` when scraping
- include hyperlink text in DOCX exports
- document the new behaviour

## Testing
- `python3 -m py_compile scrape_sas.py`

